### PR TITLE
Add the 'sass' gem as a dependency.

### DIFF
--- a/bootstrap-editable-rails.gemspec
+++ b/bootstrap-editable-rails.gemspec
@@ -18,5 +18,5 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
   gem.add_dependency "railties", ">= 3.1"
-  gem.add_dependency "sass", "~> 3.4.15"
+  gem.add_dependency "sass-rails"
 end

--- a/bootstrap-editable-rails.gemspec
+++ b/bootstrap-editable-rails.gemspec
@@ -18,4 +18,5 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
   gem.add_dependency "railties", ">= 3.1"
+  gem.add_dependency "sass", "~> 3.4.15"
 end


### PR DESCRIPTION
Add the 'sass' gem as a dependency to prevent failure during "rake assets:precompile" (if a project is already including sass, this doesn't occur).