### PR TITLE
Turn regex asset path into globbing pattern

### DIFF
--- a/lib/bootstrap-editable-rails.rb
+++ b/lib/bootstrap-editable-rails.rb
@@ -9,7 +9,7 @@ module Bootstrap
           ::ActiveSupport.on_load(:action_view) do
             ::ActionView::Base.send :include, Bootstrap::Editable::Rails::ViewHelper
           end
-          app.config.assets.precompile << %r(bootstrap-editable/.*\.(?:png|gif)$)
+          app.config.assets.precompile << "bootstrap-editable/**/*.{gif,png}"
         end
       end
     end


### PR DESCRIPTION
Rails 6 seems to not like regexes anymore, making it necessary to use a globbing patter instead.